### PR TITLE
fix warnings in Elixir 1.5

### DIFF
--- a/mixbump
+++ b/mixbump
@@ -12,6 +12,7 @@ if length(System.argv) > 0 do
     [command, path | _] = System.argv
     command = 
     case command do
+    "d" -> "diff"
     "a" -> "add"
     "c" -> "commit"
     end
@@ -38,8 +39,8 @@ end
  if File.exists?(mix_exs_path), do: mix_exs_path, else: nil
 
 mix_exs_path = 
-if command && command != "add" && command != "commit" do
-  IO.puts "Unrecognized command #{command}; \"add\" and \"commit\" are supported"
+if command && command != "diff" && command != "add" && command != "commit" do
+  IO.puts "Unrecognized command #{command}; \"diff\", \"add\" and \"commit\" are supported"
   nil
 else
   mix_exs_path
@@ -47,7 +48,6 @@ end
 
 if !is_nil(mix_exs_path) do
   # Update mix.exs in-place.
-  IO.puts "Bumping #{mix_exs_path}"
   File.write mix_exs_path, (
     File.read!(mix_exs_path)
     |> String.split("\n")
@@ -56,7 +56,7 @@ if !is_nil(mix_exs_path) do
         {sub, _} = Integer.parse(sub)
         old_version = "#{major}.#{minor}.#{sub}"
         new_version = "#{major}.#{minor}.#{sub + 1}"
-        IO.puts "Bumping from #{old_version} to #{new_version}"
+        IO.puts "Bumping \"#{mix_exs_path}\", from #{old_version} to #{new_version}"
         "version: \"#{major}.#{minor}.#{sub + 1}\""
       end)
     end)
@@ -64,6 +64,9 @@ if !is_nil(mix_exs_path) do
   )
 
   case command do
+    "diff" ->
+      {output, _} = System.cmd "git", ~w[diff mix.exs], cd: Path.dirname(mix_exs_path)
+      IO.puts output
     "add" ->
       System.cmd "git", ~w[add mix.exs], cd: Path.dirname(mix_exs_path)
       {output, _} = System.cmd "git", ~w[diff --cached], cd: Path.dirname(mix_exs_path)
@@ -74,15 +77,15 @@ if !is_nil(mix_exs_path) do
       {output, _} = System.cmd "git", ~w[diff HEAD~], cd: Path.dirname(mix_exs_path)
       IO.puts output
     _ ->
-      {output, _} = System.cmd "git", ~w[diff mix.exs], cd: Path.dirname(mix_exs_path)
-      IO.puts output
+      nil
   end
 
 else
   IO.puts """
   Please specify the path to a valid mix.exs file.
   Usage: mixbump path/to/mix.exs
-         mixbump -a path/to/mix.exs (git add mix.exs)
-         mixbump -c path/to/mix.exs (git add mix.exs; git commit -m "Version bump")
+         mixbump d path/to/mix.exs (git diff)
+         mixbump a path/to/mix.exs (git add mix.exs)
+         mixbump c path/to/mix.exs (git add mix.exs; git commit -m "Version bump")
   """
 end

--- a/mixbump
+++ b/mixbump
@@ -1,31 +1,51 @@
 #!/usr/local/bin/elixir
 
 # get mix.exs path
+{command, mix_exs_path} = 
 if length(System.argv) > 0 do
+
   if length(System.argv) == 1 do
     # No command specified, just bump
-    [mix_exs_path | _] = System.argv
-    command = nil
+    [path | _] = System.argv
+    { nil, path}
   else
-    [command, mix_exs_path | _] = System.argv
-    if command == "a", do: command = "add"
-    if command == "c", do: command = "commit"
+    [command, path | _] = System.argv
+    command = 
+    case command do
+    "a" -> "add"
+    "c" -> "commit"
+    end
+    {command, path}
   end
 
-  # Allow specifying path without mix.exs if it contains it.
-  if !Regex.match?(~r/mix.exs$/, mix_exs_path) && File.exists?("#{mix_exs_path}/mix.exs") do
-    mix_exs_path = Path.join [mix_exs_path, "mix.exs"]
-  end
 else
-  mix_exs_path = nil
+  {nil, nil}
 end
 
+# default to current directory, if no path specified
+mix_exs_path = 
+if is_nil(mix_exs_path), do: ".", else: mix_exs_path
+
+# Allow specifying path without mix.exs if it contains it.
+mix_exs_path = 
+if !Regex.match?(~r/mix.exs$/, mix_exs_path) do
+  Path.join [mix_exs_path, "mix.exs"]
+else
+  mix_exs_path
+end
+
+ mix_exs_path = 
+ if File.exists?(mix_exs_path), do: mix_exs_path, else: nil
+
+mix_exs_path = 
 if command && command != "add" && command != "commit" do
-  mix_exs_path = nil
   IO.puts "Unrecognized command #{command}; \"add\" and \"commit\" are supported"
+  nil
+else
+  mix_exs_path
 end
 
-if mix_exs_path && File.exists?(mix_exs_path) do
+if !is_nil(mix_exs_path) do
   # Update mix.exs in-place.
   IO.puts "Bumping #{mix_exs_path}"
   File.write mix_exs_path, (
@@ -62,5 +82,7 @@ else
   IO.puts """
   Please specify the path to a valid mix.exs file.
   Usage: mixbump path/to/mix.exs
+         mixbump -a path/to/mix.exs (git add mix.exs)
+         mixbump -c path/to/mix.exs (git add mix.exs; git commit -m "Version bump")
   """
 end


### PR DESCRIPTION
Hi Max, Thanks for writing MixBump. I found it useful, but annoying with the warning messages from old coding style. Here's a pull request, with all the warnings fixed.

I've also allowed for the default mix.exs directory to be the current directory: '.', which makes it slightly easier for me to type: "mixbump".

Cheers,
Warwick